### PR TITLE
Properly fall back to `http.Server` when tlsconfig is missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function Server(tlsconfig, requestListener) {
     tlsconfig = undefined;
   }
 
-  if (typeof tlsconfig === 'object') {
+  if (typeof tlsconfig === 'object' && tlsconfig !== null) {
     this.removeAllListeners('connection');
 
     https.Server.call(this, tlsconfig, requestListener);

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ function Server(tlsconfig, requestListener) {
     this.allowHalfOpen = true;
     this.httpAllowHalfOpen = false;
   } else
-    http.Server.call(this, requestListener);
+    return new http.Server(requestListener);
 }
 inherits(Server, https.Server);
 

--- a/test/test-no-https.js
+++ b/test/test-no-https.js
@@ -1,0 +1,45 @@
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+var assert = require('assert');
+
+var common = require(__dirname + '/common');
+var httpolyglot = require(__dirname + '/../lib/index');
+
+var srv = httpolyglot.createServer(null, common.mustCall(function(req, res) {
+  res.end(req.socket.encrypted ? 'https' : 'http');
+}, 1));
+assert(srv instanceof http.Server);
+srv.listen(0, '127.0.0.1', common.mustCall(function() {
+  var port = this.address().port;
+  var count = 2;
+  function done() {
+    if (--count === 0) {
+      srv.close();
+    }
+  }
+
+  http.get({
+    host: '127.0.0.1',
+    port: port
+  }, common.mustCall(function(res) {
+    var body = '';
+    res.on('data', function(data) {
+      body += data;
+    }).on('end', common.mustCall(function() {
+      assert.strictEqual(body, 'http');
+      done();
+    }));
+  }));
+
+  https.get({
+    host: '127.0.0.1',
+    port: port,
+    rejectUnauthorized: false
+  }, function() {
+    assert(false, 'The request should have failed for the lack of TLS config');
+  }).on('error', common.mustCall(function(err) {
+    assert.strictEqual(err.code, 'ECONNRESET');
+    done();
+  }));
+}));


### PR DESCRIPTION
The common pattern in the implementation of Server (including the [http.Server](https://github.com/nodejs/node/blob/8a12368a2090440bfd798abf68e5009445a8dced/lib/_http_server.js#L231-L232) and [https.Server](https://github.com/nodejs/node/blob/8a12368a2090440bfd798abf68e5009445a8dced/lib/https.js#L12-L13) objects from the Node.js core) is the following (note that `this` is completely ignored):

    if (!(this instanceof Server)) return new Server(...arguments);

There are three relevant `Server` implementations, with the following inheritance tree:

    - tls.Server
     +-- http.Server
     +-- https.Server
       +-- httpolyglot.Server

When `httpolyglot.Server` is constructed without TLS config, it [falls back to constructing itself using `http.Server`](https://github.com/mscdex/httpolyglot/blob/1c6c4af65f4cf95a32c918d0fdcc532e0c095740/lib/index.js#L8-L39):

    // this is an instance of httpolyglot.Server
    http.Server.call(this, requestListener);

But `this` is not an instance of `http.Server`, so a new `http.Server` instance is created (and discarded) and `this` is not modified. So, when `listen()` is called, the server starts listening on a port
but does not have any request handlers. Consequently, when a http(s) request is sent to the server, the connection is accepted but the request is never processed.

To fix this, be explicit and return the new instance of `http.Server` (as done in this PR).