### PR TITLE
Don't allow half-open TLS connections

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,8 @@ if (isOldNode) {
       if (firstByte < 32 || firstByte >= 127) {
         // tls/ssl
         socket.ondata = null;
+        // TLS sockets don't allow half open
+        socket.allowHalfOpen = false;
         self._tlsHandler(socket);
         socket.push(d.slice(start, end));
       } else {
@@ -91,6 +93,8 @@ if (isOldNode) {
       socket.unshift(data);
       if (firstByte < 32 || firstByte >= 127) {
         // tls/ssl
+        // TLS sockets don't allow half open
+        socket.allowHalfOpen = false;
         this._tlsHandler(socket);
       } else
         this.__httpSocketHandler(socket);


### PR DESCRIPTION
I'm trying to detect clients rejecting my HTTPS certificate, using httpolyglot.

With the current httpolyglot server, if a client cleanly closes a TLS connection after the server hello (i.e. when it decides it doesn't like the certificate), the current httpolyglot never fires a `tlsClientError` event, whilst `https.Server` does.

I've hit this because that's the behaviour of Node 12 TLS clients - they cleanly close connections at this point (in Node 10, the handshake completes, `secureConnection` fires, and then the client closes the connection without sending any data - that works fine).

The below test demonstrates the issue. I haven't committed it, because it only works with Node 12, but hopefully it shows what I'm talking about.

```js
var fs = require('fs');
var https = require('https');
var assert = require('assert');

var common = require(__dirname + '/common');
var httpolyglot = require(__dirname + '/../lib/index');

var srv = httpolyglot.createServer({
  key: fs.readFileSync(__dirname + '/fixtures/server.key'),
  cert: fs.readFileSync(__dirname + '/fixtures/server.crt')
}, function() {
  assert(false, 'Request handler should not be called');
})

srv.listen(0, '127.0.0.1', common.mustCall(function() {
  var port = this.address().port;

  var request = https.get({
    host: '127.0.0.1',
    port: port,
    rejectUnauthorized: true
  });
  request.on('error', common.mustCall(function (error) {
    assert(
      /certificate/.test(error.message),
      'Request should be rejected with a certificate error'
    );
  }));
}));

// Without this change, this is never called:
srv.on('tlsClientError', common.mustCall(function() {
  srv.close();
}));
```

This appears to happen because httpolyglot allows half-open TLS connections, whilst `https.Server` does not. As far as I can tell half-open connections are only allowed by default on `http.Server`, so I've changed the code here to disable it on sockets once we know that they are definitely TLS.

With this change, the above test passes.